### PR TITLE
Optional dependencies

### DIFF
--- a/lib/url_finder/readers/html_reader.rb
+++ b/lib/url_finder/readers/html_reader.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
+begin
+  require 'nokogiri'
+rescue LoadError
+end
+
 require 'url_finder/readers/base_reader'
 
 module UrlFinder
@@ -10,6 +14,8 @@ module UrlFinder
     # @return [Array<String>] the found URLs
     def urls
       @urls ||= begin
+        raise('nokogiri gem must be installed') unless defined?(Nokogiri)
+
         document = Nokogiri::HTML(content)
         document.css('a').map { |e| e['href'] }.compact
       end

--- a/lib/url_finder/readers/markdown_reader.rb
+++ b/lib/url_finder/readers/markdown_reader.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require 'kramdown'
+begin
+  require 'kramdown'
+rescue LoadError
+end
+
 require 'url_finder/readers/base_reader'
 require 'url_finder/readers/html_reader'
 
@@ -11,6 +15,8 @@ module UrlFinder
     # @return [Array<String>] the found URLs
     def urls
       @urls ||= begin
+        raise('kramdown gem must be installed') unless defined?(Kramdown)
+
         html = Kramdown::Document.new(content).to_html
         HTMLReader.new(html).urls
       end

--- a/spec/url_finder/readers/sitemap_reader_spec.rb
+++ b/spec/url_finder/readers/sitemap_reader_spec.rb
@@ -2,15 +2,9 @@ require 'spec_helper'
 
 require 'url_finder/readers/sitemap_reader'
 
-RSpec.describe UrlFinder::Sitemap do
+RSpec.describe UrlFinder::SitemapReader do
   describe '#new' do
-    it 'raises error REXML::ParseException when strict mode is true' do
-      expect do
-        described_class.new('<wat></wat><man></man>', strict: true)
-      end.to raise_error(REXML::ParseException)
-    end
-
-    it 'if strict mode false it swallows XML errors' do
+    it 'it swallows XML errors' do
       sitemap = described_class.new('<buren></buren><stam></stam>')
       expect(sitemap.urls).to be_empty
     end

--- a/url_finder.gemspec
+++ b/url_finder.gemspec
@@ -24,10 +24,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # TODO: Consider making kramdown & nokogiri optional
-  spec.add_dependency 'kramdown', '~> 1.17'
-  spec.add_dependency 'nokogiri', '~> 1.8'
+  # optional dependencies
+  spec.add_development_dependency 'kramdown', '~> 1.17'
+  spec.add_development_dependency 'nokogiri', '~> 1.8'
 
+  # dev dependencies
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
Make `nokogiri` and `kramdown` optional - raise an error with a friendly message when required gems aren't installed.

➕ If you don't want to parse HTML or markdown you wont need `nokogiri`
➖ Will be a bit annoying when using the CLI when you then have to run `gem install kramdown` and `gem install nokogiri` 

